### PR TITLE
Add AI YouTube Studio webapp (script→scenes, image/TTS, render worker, UI and docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# test-gpt
+# AI 유튜브 자동 제작 스튜디오
+
+대본 입력만으로 장르별 씬 분할, 이미지 프롬프트/이미지 생성, 썸네일 3종 제안, Google TTS 합성, 자막 스타일링, 로컬 영상 생성/다운로드까지 연결하는 웹앱입니다.
+
+## 실행
+```bash
+python3 -m http.server 4173
+# 브라우저: http://localhost:4173
+```
+
+## 구현 기능
+- Google 이메일 계정 전환 UX 제공(OAuth Client ID 없이 계정 선택창 열기)
+- 장르 선택: 야담, 시니어, 성인로멘스, 무협애니메이션, 경제뉴스(졸라맨 케릭터), 코인뉴스
+- Gemini 기반 씬 분할 + 이미지 프롬프트 + 썸네일 3종 생성
+- 무료 이미지 생성(Pollinations) + 재생성 + 드래그앤드롭 업로드
+- Google Cloud TTS API Key 저장/삭제/연결확인 + 씬별 TTS 생성
+- Google Cloud TTS 화자 목록(한국어 + 성별 표기)
+- 자막 스타일: 폰트 10종, 크기/위치/색상/배경/1줄·2줄
+- Web Worker + OffscreenCanvas 기반 로컬 영상 렌더링 + 자동 다운로드
+- 씬 이미지/TTS/프롬프트/프로젝트 JSON 일괄 ZIP 다운로드
+- Antigravity/Genspark 재구현용 문서 포함(`docs/genspark-agent-instructions.md`)
+
+## 보안/운영 권장
+- 실제 운영에서는 API Key를 프런트에 두지 말고 백엔드 토큰 프록시 사용 권장
+- 사용량 초과 시 계정 순환 정책(계정풀, 쿨다운, 백오프) 서버에서 관리 권장
+- 생성물 저작권/정책 필터 체인 추가 권장

--- a/app.js
+++ b/app.js
@@ -1,0 +1,476 @@
+const STORAGE_KEYS = {
+  googleEmail: 'studio_google_email',
+  ttsApiKey: 'studio_gcp_tts_api_key',
+};
+
+const state = {
+  accountEmail: null,
+  scenes: [],
+  thumbnails: [],
+  ttsAudioByScene: new Map(),
+  renderedVideo: null,
+  ttsConnected: false,
+};
+
+const subtitleFonts = [
+  'Noto Sans KR', 'Black Han Sans', 'Jua', 'Do Hyeon', 'Nanum Gothic',
+  'Nanum Myeongjo', 'Gowun Dodum', 'Gowun Batang', 'Poor Story', 'Arial',
+];
+
+const checklist = [
+  '대본 버전관리/자동저장 + 프로젝트 복구 기능',
+  '씬별 BGM/효과음 트랙 분리 + 볼륨 믹서',
+  '저작권/초상권 필터 + 금칙어 검수',
+  '썸네일 A/B 테스트용 문구 자동 생성',
+  '유튜브 업로드 메타데이터(제목/설명/태그) 자동 작성',
+  '실패한 씬만 재시도하는 복구 큐',
+  'GPU/메모리 상태 기반 해상도 자동 조절',
+  '작업 로그/진행률 이벤트 저장(크래시 복구)',
+  'Antigravity/Genspark 가져오기용 JSON Export',
+  '팀 협업용 코멘트/승인 워크플로',
+];
+
+const $ = (id) => document.getElementById(id);
+
+window.addEventListener('DOMContentLoaded', async () => {
+  subtitleFonts.forEach((font) => {
+    const opt = document.createElement('option');
+    opt.value = font;
+    opt.textContent = font;
+    $('subtitleFont').appendChild(opt);
+  });
+
+  checklist.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    $('checklist').appendChild(li);
+  });
+
+  bindEvents();
+  restoreSavedSettings();
+
+  if (getSavedTtsApiKey()) {
+    await checkTtsApiConnection(true);
+  }
+});
+
+function bindEvents() {
+  $('saveEmailBtn').onclick = saveGoogleEmail;
+  $('switchEmailBtn').onclick = startEmailSwitch;
+  $('openGoogleAccountBtn').onclick = openGoogleAccountChooser;
+
+  $('analyzeBtn').onclick = analyzeScript;
+
+  $('saveTtsApiBtn').onclick = saveTtsApiKey;
+  $('checkTtsApiBtn').onclick = () => checkTtsApiConnection();
+  $('deleteTtsApiBtn').onclick = deleteTtsApiKey;
+  $('loadVoicesBtn').onclick = loadVoices;
+  $('generateTtsBtn').onclick = generateTtsForScenes;
+
+  $('renderBtn').onclick = renderVideo;
+  $('downloadAllBtn').onclick = downloadAll;
+}
+
+function restoreSavedSettings() {
+  const savedEmail = localStorage.getItem(STORAGE_KEYS.googleEmail);
+  const savedTtsKey = localStorage.getItem(STORAGE_KEYS.ttsApiKey);
+
+  if (savedEmail) {
+    $('googleEmail').value = savedEmail;
+    state.accountEmail = savedEmail;
+    $('accountInfo').textContent = savedEmail;
+  }
+
+  if (savedTtsKey) {
+    $('gcpApiKey').value = savedTtsKey;
+    $('ttsApiStatus').value = '저장됨 (연결 확인 필요)';
+  }
+}
+
+function saveGoogleEmail() {
+  const email = $('googleEmail').value.trim();
+  if (!isValidEmail(email)) {
+    alert('유효한 Google 이메일을 입력하세요.');
+    return;
+  }
+  localStorage.setItem(STORAGE_KEYS.googleEmail, email);
+  state.accountEmail = email;
+  $('accountInfo').textContent = email;
+  $('emailStatus').textContent = '이메일 저장 완료. 무료 한도 소진 시 이 값을 새 계정으로 바꾼 뒤 전환을 진행하세요.';
+}
+
+function startEmailSwitch() {
+  const currentEmail = $('googleEmail').value.trim();
+  if (!isValidEmail(currentEmail)) {
+    alert('먼저 현재 사용 중인 Google 이메일을 입력/저장하세요.');
+    return;
+  }
+  $('emailStatus').textContent = '계정 전환 시작: 새 Google 이메일로 로그인한 뒤, 이 입력칸에 새 이메일을 저장하고 계속 진행하세요.';
+  openGoogleAccountChooser();
+}
+
+function openGoogleAccountChooser() {
+  const switchUrl = 'https://accounts.google.com/Logout?continue=https://accounts.google.com/AccountChooser';
+  window.open(switchUrl, '_blank', 'noopener,noreferrer');
+}
+
+async function analyzeScript() {
+  const script = $('scriptInput').value.trim();
+  const genre = $('genre').value;
+  const sceneCount = Number($('sceneCount').value || 8);
+  const apiKey = $('geminiApiKey').value.trim();
+  if (!script || !apiKey) return alert('대본과 Gemini API Key를 입력하세요.');
+
+  setStatus('Gemini 분석 중...');
+  const prompt = `너는 유튜브 제작 AI다. 장르: ${genre}. 아래 대본을 ${sceneCount}개 씬으로 분할하고 JSON으로 응답해.
+필드: scenes[{id,text,imagePrompt,durationSec}], thumbnails[{title,hookText,imagePrompt}], subtitlesStyleTip.
+대본:\n${script}`;
+
+  try {
+    const model = $('geminiModel').value.trim() || 'gemini-3.0-flash-preview';
+    const res = await geminiRequest(prompt, apiKey, model);
+    const parsed = safeJsonParse(res);
+
+    state.scenes = await Promise.all((parsed.scenes || []).map(async (scene, idx) => ({
+      ...scene,
+      id: scene.id ?? idx + 1,
+      blob: await generateImage(scene.imagePrompt || `${genre} 스타일`, scene.id ?? idx + 1),
+    })));
+
+    state.thumbnails = parsed.thumbnails || [];
+    renderScenes();
+    renderThumbnails();
+    setStatus('씬/썸네일 생성 완료');
+  } catch (e) {
+    const message = String(e.message);
+    if (message.includes('RESOURCE_EXHAUSTED') || message.includes('429')) {
+      setStatus('무료 한도 소진 감지: Google 이메일 계정 전환 후 재시도');
+      alert('무료 한도 소진. [계정 전환 시작] 버튼으로 새 Google 이메일 계정 로그인 후 다시 시도하세요.');
+    } else {
+      setStatus(`오류: ${e.message}`);
+    }
+  }
+}
+
+async function geminiRequest(prompt, apiKey, model) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.8, responseMimeType: 'application/json' },
+    }),
+  });
+  const data = await response.json();
+  if (!response.ok) throw new Error(JSON.stringify(data));
+  return data.candidates?.[0]?.content?.parts?.[0]?.text || '{}';
+}
+
+function safeJsonParse(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    const cleaned = text.replace(/```json|```/g, '').trim();
+    return JSON.parse(cleaned);
+  }
+}
+
+async function generateImage(prompt, seed) {
+  const encoded = encodeURIComponent(`${prompt}, cinematic, high quality, seed=${seed}`);
+  const res = await fetch(`https://image.pollinations.ai/prompt/${encoded}`);
+  return res.blob();
+}
+
+function renderScenes() {
+  const root = $('scenes');
+  root.innerHTML = '';
+
+  state.scenes.forEach((scene, idx) => {
+    const div = document.createElement('div');
+    div.className = 'scene';
+    const imageUrl = URL.createObjectURL(scene.blob);
+
+    div.innerHTML = `
+      <h3>씬 ${idx + 1}</h3>
+      <label>대본<textarea rows="3" data-k="text">${scene.text || ''}</textarea></label>
+      <label>이미지 프롬프트<textarea rows="2" data-k="imagePrompt">${scene.imagePrompt || ''}</textarea></label>
+      <img src="${imageUrl}" alt="scene-${idx}" />
+      <div class="actions">
+        <button data-act="regen">이미지 재생성</button>
+        <button data-act="download">이미지 다운로드</button>
+        <label>드래그앤드롭/파일 삽입<input type="file" data-act="upload" accept="image/*" /></label>
+      </div>`;
+
+    div.querySelectorAll('textarea').forEach((ta) => {
+      ta.oninput = () => {
+        scene[ta.dataset.k] = ta.value;
+      };
+    });
+
+    div.querySelector('[data-act="regen"]').onclick = async () => {
+      scene.blob = await generateImage(scene.imagePrompt, scene.id + Date.now());
+      renderScenes();
+    };
+
+    div.querySelector('[data-act="download"]').onclick = () => {
+      downloadBlob(scene.blob, `scene-${idx + 1}.png`);
+    };
+
+    div.querySelector('[data-act="upload"]').onchange = async (e) => {
+      const f = e.target.files[0];
+      if (!f) return;
+      scene.blob = f;
+      renderScenes();
+    };
+
+    div.ondragover = (e) => e.preventDefault();
+    div.ondrop = async (e) => {
+      e.preventDefault();
+      const f = [...e.dataTransfer.files][0];
+      if (f?.type.startsWith('image/')) {
+        scene.blob = f;
+        renderScenes();
+      }
+    };
+
+    root.appendChild(div);
+  });
+}
+
+function renderThumbnails() {
+  const root = $('thumbnails');
+  root.innerHTML = '';
+  state.thumbnails.slice(0, 3).forEach((t, i) => {
+    const div = document.createElement('article');
+    div.className = 'thumb';
+    div.innerHTML = `<h4>썸네일 ${i + 1}</h4><p><b>제목:</b> ${t.title || ''}</p><p><b>후킹카피:</b> ${t.hookText || ''}</p><p><b>이미지 프롬프트:</b> ${t.imagePrompt || ''}</p>`;
+    root.appendChild(div);
+  });
+}
+
+function getSavedTtsApiKey() {
+  return localStorage.getItem(STORAGE_KEYS.ttsApiKey) || '';
+}
+
+async function saveTtsApiKey() {
+  const key = $('gcpApiKey').value.trim();
+  if (!key) {
+    alert('저장할 Google Cloud TTS API Key를 입력하세요.');
+    return;
+  }
+
+  const ok = await checkTtsApiConnection(false, key);
+  if (!ok) return;
+
+  localStorage.setItem(STORAGE_KEYS.ttsApiKey, key);
+  $('ttsApiStatus').value = '정상 연결됨 (저장 완료)';
+  setStatus('TTS API 저장 및 연결 확인 완료');
+}
+
+function deleteTtsApiKey() {
+  localStorage.removeItem(STORAGE_KEYS.ttsApiKey);
+  $('gcpApiKey').value = '';
+  $('voiceSelect').innerHTML = '';
+  $('ttsApiStatus').value = '미연결 (API 삭제됨)';
+  state.ttsConnected = false;
+  setStatus('TTS API 삭제 완료');
+}
+
+async function checkTtsApiConnection(silent = false, overrideKey = null) {
+  const key = (overrideKey || $('gcpApiKey').value || getSavedTtsApiKey()).trim();
+  if (!key) {
+    if (!silent) alert('Google Cloud TTS API Key를 입력하세요.');
+    $('ttsApiStatus').value = '미연결';
+    return false;
+  }
+
+  try {
+    const res = await fetch(`https://texttospeech.googleapis.com/v1/voices?languageCode=ko-KR&key=${key}`);
+    const data = await res.json();
+    if (!res.ok || data.error) {
+      throw new Error(data.error?.message || '연결 실패');
+    }
+
+    state.ttsConnected = true;
+    $('ttsApiStatus').value = '정상 연결됨';
+    if (!silent) setStatus(`TTS 연결 확인 완료 (${(data.voices || []).length}개 화자 확인)`);
+    return true;
+  } catch (error) {
+    state.ttsConnected = false;
+    $('ttsApiStatus').value = `연결 실패: ${error.message}`;
+    if (!silent) alert(`TTS 연결 실패: ${error.message}`);
+    return false;
+  }
+}
+
+async function loadVoices() {
+  const key = ($('gcpApiKey').value.trim() || getSavedTtsApiKey()).trim();
+  if (!key) return alert('Google Cloud TTS API Key를 먼저 저장하세요.');
+
+  const ok = await checkTtsApiConnection(false, key);
+  if (!ok) return;
+
+  const res = await fetch(`https://texttospeech.googleapis.com/v1/voices?languageCode=ko-KR&key=${key}`);
+  const data = await res.json();
+  const voices = data.voices || [];
+
+  $('voiceSelect').innerHTML = '';
+  voices.forEach((v) => {
+    const genderMap = { MALE: '남성', FEMALE: '여성', NEUTRAL: '중성' };
+    const opt = document.createElement('option');
+    opt.value = v.name;
+    opt.textContent = `${v.name} (${genderMap[v.ssmlGender] || v.ssmlGender})`;
+    $('voiceSelect').appendChild(opt);
+  });
+
+  setStatus(`${voices.length}개 화자 로드`);
+}
+
+async function generateTtsForScenes() {
+  const key = ($('gcpApiKey').value.trim() || getSavedTtsApiKey()).trim();
+  const voiceName = $('voiceSelect').value;
+  if (!key || !voiceName || state.scenes.length === 0) {
+    return alert('TTS API 저장/연결 확인, 화자 선택, 씬 생성 여부를 확인하세요.');
+  }
+
+  const ok = await checkTtsApiConnection(false, key);
+  if (!ok) return;
+
+  for (let i = 0; i < state.scenes.length; i += 1) {
+    const scene = state.scenes[i];
+    const res = await fetch(`https://texttospeech.googleapis.com/v1/text:synthesize?key=${key}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        input: { text: scene.text || '' },
+        voice: { languageCode: 'ko-KR', name: voiceName },
+        audioConfig: { audioEncoding: 'MP3' },
+      }),
+    });
+    const data = await res.json();
+    if (data.audioContent) {
+      const blob = base64ToBlob(data.audioContent, 'audio/mpeg');
+      state.ttsAudioByScene.set(scene.id, blob);
+    }
+    setProgress(Math.round(((i + 1) / state.scenes.length) * 100));
+  }
+
+  setStatus('TTS 생성 완료');
+}
+
+async function renderVideo() {
+  if (state.scenes.length === 0) return alert('씬을 먼저 생성하세요.');
+  setStatus('영상 렌더링 시작 (백그라운드 워커)...');
+
+  const worker = new Worker('worker.js');
+  worker.onmessage = (e) => {
+    if (e.data.type === 'PROGRESS') {
+      setProgress(e.data.value);
+    }
+
+    if (e.data.type === 'RENDER_DONE') {
+      if (state.renderedVideo) URL.revokeObjectURL(state.renderedVideo);
+      state.renderedVideo = URL.createObjectURL(e.data.blob);
+      $('preview').src = state.renderedVideo;
+      downloadBlob(e.data.blob, 'final-video.webm');
+      setStatus('영상 생성 완료 + 자동 다운로드');
+      cleanupMemory();
+      worker.terminate();
+    }
+  };
+
+  worker.postMessage({
+    type: 'RENDER_REQUEST',
+    payload: {
+      scenes: state.scenes.map((s) => ({
+        blob: s.blob,
+        subtitle: s.text,
+        durationSec: s.durationSec || 4,
+      })),
+      subtitle: {
+        font: $('subtitleFont').value,
+        sizePx: Number($('subtitleSize').value),
+        yPercent: Number($('subtitleY').value),
+        color: $('subtitleColor').value,
+        bgColor: $('subtitleBg').value,
+        lines: $('subtitleLines').value,
+      },
+    },
+  });
+}
+
+async function downloadAll() {
+  const zip = new JSZip();
+  state.scenes.forEach((scene, i) => {
+    zip.file(`scenes/scene-${i + 1}.txt`, scene.text || '');
+    zip.file(`prompts/scene-${i + 1}.prompt.txt`, scene.imagePrompt || '');
+    zip.file(`images/scene-${i + 1}.png`, scene.blob);
+    const tts = state.ttsAudioByScene.get(scene.id);
+    if (tts) zip.file(`tts/scene-${i + 1}.mp3`, tts);
+  });
+  state.thumbnails.forEach((t, i) => {
+    zip.file(`thumbnails/thumb-${i + 1}.json`, JSON.stringify(t, null, 2));
+  });
+  zip.file('export/antigravity-project.json', JSON.stringify(buildProjectExport(), null, 2));
+  const blob = await zip.generateAsync({ type: 'blob' });
+  downloadBlob(blob, 'youtube-ai-project.zip');
+}
+
+function buildProjectExport() {
+  return {
+    meta: {
+      createdAt: new Date().toISOString(),
+      genre: $('genre').value,
+      googleEmail: $('googleEmail').value.trim() || state.accountEmail,
+      subtitle: {
+        font: $('subtitleFont').value,
+        sizePx: Number($('subtitleSize').value),
+        lines: $('subtitleLines').value,
+      },
+      ttsStatus: $('ttsApiStatus').value,
+    },
+    scenes: state.scenes.map((s, i) => ({
+      index: i + 1,
+      text: s.text,
+      imagePrompt: s.imagePrompt,
+      durationSec: s.durationSec || 4,
+    })),
+    thumbnails: state.thumbnails,
+    integrations: {
+      antigravity: 'import export/antigravity-project.json',
+      gensparkAgent: 'use docs/genspark-agent-instructions.md as bootstrap',
+    },
+  };
+}
+
+function cleanupMemory() {
+  if (window.gc) window.gc();
+}
+
+function downloadBlob(blob, filename) {
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+}
+
+function base64ToBlob(base64, type) {
+  const bytes = atob(base64);
+  const arr = new Uint8Array(bytes.length);
+  for (let i = 0; i < bytes.length; i += 1) arr[i] = bytes.charCodeAt(i);
+  return new Blob([arr], { type });
+}
+
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function setProgress(v) {
+  $('progress').value = v;
+}
+
+function setStatus(msg) {
+  $('status').textContent = msg;
+}

--- a/docs/genspark-agent-instructions.md
+++ b/docs/genspark-agent-instructions.md
@@ -1,0 +1,73 @@
+# Genspark Agent 재구현용 상세 지침
+
+## 목표
+사용자가 대본만 넣고 다음을 원클릭으로 완료:
+1. 장르별 씬 분할
+2. 씬별 이미지 생성/수동교체
+3. 썸네일 3개 생성
+4. TTS 나레이션 합성
+5. 자막 스타일 반영
+6. 로컬 영상 렌더링 + 다운로드
+7. Antigravity 재편집 호환
+
+## 필수 모듈
+- Auth: Google OAuth(다중 계정 전환 지원)
+- LLM: Gemini Flash 계열 모델 + 한도 초과 감지 후 계정 전환 흐름
+- Image: 무료 생성 API + 수동 업로드(드래그앤드롭)
+- TTS: Google Cloud Text-to-Speech 유료 API
+- Render: Web Worker + OffscreenCanvas + MediaRecorder
+- Export: ZIP 번들 + 프로젝트 JSON(antigravity import)
+
+## 구현 우선순위
+1. Project/Scene 데이터 모델 고정
+2. OAuth 및 API 키 관리 UI
+3. Script→Scene 파이프라인
+4. Scene 이미지 생성 파이프라인
+5. TTS 파이프라인
+6. Render 파이프라인
+7. 다운로드/복구/재시도
+
+## 권장 데이터 스키마
+```json
+{
+  "projectId": "uuid",
+  "genre": "경제뉴스(졸라맨 케릭터)",
+  "script": "...",
+  "scenes": [
+    {
+      "id": 1,
+      "text": "씬 내레이션",
+      "imagePrompt": "이미지 프롬프트",
+      "imageAsset": "path-or-blob",
+      "audioAsset": "path-or-blob",
+      "durationSec": 4
+    }
+  ],
+  "thumbnails": [
+    {"title": "", "hookText": "", "imagePrompt": ""}
+  ],
+  "subtitleStyle": {
+    "font": "Noto Sans KR",
+    "sizePx": 48,
+    "lineMode": 2,
+    "color": "#fff",
+    "bgColor": "#000"
+  }
+}
+```
+
+## 메모리/성능 전략
+- Blob URL 즉시 revoke
+- 미리보기 해상도/출력 해상도 분리
+- 씬 단위 스트리밍 렌더링(전체 프레임 캐싱 금지)
+- 실패 씬만 재시도 큐
+- 백그라운드 탭 타이머 쓰로틀 회피를 위해 Worker 기반 렌더
+
+## Antigravity 연동 포맷
+- `export/antigravity-project.json` 포함
+- 씬 순서, 타임라인, 자막 스타일, asset 매핑 정보를 직렬화
+
+## 품질 보증
+- 장르별 템플릿 프롬프트 유지
+- 썸네일 문구 길이 제한(모바일 우선)
+- 혐오/선정성/허위정보 검수 체인 추가

--- a/index.html
+++ b/index.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI 유튜브 자동 제작 스튜디오</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Black+Han+Sans&family=Noto+Sans+KR:wght@400;500;700&family=Jua&family=Do+Hyeon&family=Nanum+Gothic:wght@400;700&family=Nanum+Myeongjo:wght@400;700&family=Gowun+Dodum&family=Gowun+Batang:wght@400;700&family=Poor+Story&display=swap" rel="stylesheet">
+  <script defer src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script defer src="app.js"></script>
+</head>
+<body>
+  <header>
+    <h1>대본 → 유튜브 자동 제작기 (Gemini 3.0 Flash Preview)</h1>
+    <p>Google 이메일 계정 전환 + 장르 특화 이미지/썸네일/자막/영상 생성</p>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>1) 인증 & API 연결</h2>
+      <p class="hint"><b>중요:</b> OAuth Client ID 없이 진행합니다. 계정 전환은 Google 이메일 계정을 직접 바꿔서 이어서 사용합니다.</p>
+      <div class="grid two">
+        <label>Gemini API Key (AI Studio)
+          <input id="geminiApiKey" placeholder="AIza..." />
+        </label>
+        <label>Gemini 모델
+          <input id="geminiModel" value="gemini-3.0-flash-preview" />
+        </label>
+      </div>
+
+      <details>
+        <summary>Google 이메일 계정 전환 관리 (OAuth Client ID 불필요)</summary>
+        <div class="grid two">
+          <label>현재 사용할 Google 이메일
+            <input id="googleEmail" type="email" placeholder="example@gmail.com" />
+          </label>
+        </div>
+        <div class="actions">
+          <button id="saveEmailBtn">이메일 저장</button>
+          <button id="switchEmailBtn">계정 전환 시작</button>
+          <button id="openGoogleAccountBtn">Google 계정 선택창 열기</button>
+        </div>
+        <p class="hint">계정 상태: <span id="accountInfo">미설정</span></p>
+        <p class="hint" id="emailStatus">무료 한도 소진 시 [계정 전환 시작] 버튼으로 새 Google 이메일로 로그인 후 계속 진행하세요.</p>
+      </details>
+    </section>
+
+    <section class="card">
+      <h2>2) 대본/장르 입력</h2>
+      <div class="grid two">
+        <label>장르 선택
+          <select id="genre">
+            <option>야담</option>
+            <option>시니어</option>
+            <option>성인로멘스</option>
+            <option>무협애니메이션</option>
+            <option>경제뉴스(졸라맨 케릭터)</option>
+            <option>코인뉴스</option>
+          </select>
+        </label>
+        <label>씬 분할 수
+          <input id="sceneCount" type="number" min="1" max="30" value="8" />
+        </label>
+      </div>
+      <label>원본 대본
+        <textarea id="scriptInput" rows="10" placeholder="대본을 입력하면 자동으로 씬/이미지 프롬프트/썸네일 카피가 생성됩니다."></textarea>
+      </label>
+      <div class="actions">
+        <button id="analyzeBtn">씬/프롬프트/썸네일 생성</button>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>3) 장르 최적화 씬 편집 + 이미지 생성</h2>
+      <div id="scenes"></div>
+    </section>
+
+    <section class="card">
+      <h2>4) 썸네일 3종 (CTR 최적화)</h2>
+      <div id="thumbnails" class="grid three"></div>
+    </section>
+
+    <section class="card">
+      <h2>5) 자막/TTS</h2>
+      <div class="grid three">
+        <label>자막 폰트
+          <select id="subtitleFont"></select>
+        </label>
+        <label>폰트 크기(px)
+          <input id="subtitleSize" type="number" value="48" min="20" max="120" />
+        </label>
+        <label>자막 줄 수
+          <select id="subtitleLines">
+            <option value="1">한 줄</option>
+            <option value="2" selected>두 줄</option>
+          </select>
+        </label>
+        <label>자막 위치(Y%)
+          <input id="subtitleY" type="number" value="85" min="10" max="95" />
+        </label>
+        <label>자막 색상
+          <input id="subtitleColor" type="color" value="#ffffff" />
+        </label>
+        <label>배경 색상
+          <input id="subtitleBg" type="color" value="#000000" />
+        </label>
+      </div>
+
+      <details open>
+        <summary>Google Cloud TTS API 연결 / 화자 목록</summary>
+        <p class="hint">TTS는 API Key 저장 후 연결 확인(정상 연결됨) 상태에서 계속 사용됩니다.</p>
+        <div class="grid two">
+          <label>Google Cloud TTS API Key
+            <input id="gcpApiKey" placeholder="Google Cloud Text-to-Speech API Key" />
+          </label>
+          <label>연결 상태
+            <input id="ttsApiStatus" value="미연결" readonly />
+          </label>
+        </div>
+        <div class="actions">
+          <button id="saveTtsApiBtn">API 저장</button>
+          <button id="checkTtsApiBtn">연결 확인</button>
+          <button id="deleteTtsApiBtn">API 삭제</button>
+          <button id="loadVoicesBtn">화자 목록 불러오기</button>
+        </div>
+        <label>화자 (한국어 이름 + 성별)
+          <select id="voiceSelect"></select>
+        </label>
+        <div class="actions">
+          <button id="generateTtsBtn">전체 씬 TTS 생성</button>
+        </div>
+      </details>
+    </section>
+
+    <section class="card">
+      <h2>6) 영상 생성 (로컬 + 백그라운드 워커)</h2>
+      <div class="actions">
+        <button id="renderBtn">영상 생성 시작</button>
+        <button id="downloadAllBtn">전체 리소스 ZIP 다운로드</button>
+      </div>
+      <progress id="progress" value="0" max="100"></progress>
+      <p id="status">대기 중</p>
+      <video id="preview" controls></video>
+    </section>
+
+    <section class="card">
+      <h2>7) 누락되기 쉬운 핵심 체크리스트 (자동화 강화)</h2>
+      <ul id="checklist"></ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,71 @@
+:root {
+  --bg: #0f172a;
+  --card: #111827;
+  --ink: #e5e7eb;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+}
+body {
+  margin: 0;
+  font-family: 'Noto Sans KR', system-ui, sans-serif;
+  background: linear-gradient(140deg, #020617, #0f172a);
+  color: var(--ink);
+}
+header {
+  padding: 24px;
+  border-bottom: 1px solid #334155;
+}
+main {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+.card {
+  background: rgba(17, 24, 39, 0.92);
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 16px;
+}
+.grid { display: grid; gap: 12px; }
+.grid.two { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+.grid.three { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+label { display: grid; gap: 6px; color: var(--muted); }
+input, textarea, select, button {
+  font: inherit;
+  border-radius: 8px;
+  border: 1px solid #475569;
+  background: #0b1220;
+  color: var(--ink);
+  padding: 10px;
+}
+textarea { resize: vertical; }
+button {
+  cursor: pointer;
+  background: #0369a1;
+  border-color: #0ea5e9;
+}
+button:hover { filter: brightness(1.1); }
+.actions { display: flex; flex-wrap: wrap; gap: 8px; margin: 10px 0; }
+.hint { color: var(--muted); }
+.scene {
+  border: 1px dashed #64748b;
+  border-radius: 10px;
+  padding: 12px;
+  margin-bottom: 10px;
+}
+.scene img {
+  width: 100%;
+  max-width: 340px;
+  border-radius: 10px;
+  border: 1px solid #475569;
+}
+.thumb {
+  border: 1px solid #334155;
+  border-radius: 10px;
+  padding: 12px;
+  background: #0b1220;
+}
+#preview { width: 100%; max-height: 420px; }
+progress { width: 100%; height: 16px; }

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,71 @@
+self.onmessage = async (e) => {
+  const { type, payload } = e.data;
+  if (type !== 'RENDER_REQUEST') return;
+  const { scenes, subtitle, width = 1280, height = 720, fps = 30 } = payload;
+
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+  const stream = canvas.captureStream(fps);
+  const recorder = new MediaRecorder(stream, { mimeType: 'video/webm;codecs=vp9' });
+  const chunks = [];
+  recorder.ondataavailable = (evt) => chunks.push(evt.data);
+  recorder.start();
+
+  for (let i = 0; i < scenes.length; i += 1) {
+    const scene = scenes[i];
+    const bmp = await createImageBitmap(scene.blob);
+    const durationMs = Math.max(1500, (scene.durationSec || 4) * 1000);
+    const frames = Math.round((durationMs / 1000) * fps);
+
+    for (let f = 0; f < frames; f += 1) {
+      ctx.clearRect(0, 0, width, height);
+      ctx.drawImage(bmp, 0, 0, width, height);
+      drawSubtitle(ctx, scene.subtitle || scene.text || '', subtitle, width, height);
+      await new Promise((r) => setTimeout(r, 1000 / fps));
+    }
+    bmp.close();
+    self.postMessage({ type: 'PROGRESS', value: Math.round(((i + 1) / scenes.length) * 100) });
+  }
+
+  recorder.stop();
+  await new Promise((resolve) => (recorder.onstop = resolve));
+  const videoBlob = new Blob(chunks, { type: 'video/webm' });
+  self.postMessage({ type: 'RENDER_DONE', blob: videoBlob });
+};
+
+function drawSubtitle(ctx, text, subtitle, width, height) {
+  if (!text) return;
+  const lines = breakLines(text, subtitle.lines === '1' ? 24 : 12, subtitle.lines === '1' ? 1 : 2);
+  const yBase = (height * Number(subtitle.yPercent || 85)) / 100;
+  ctx.textAlign = 'center';
+  ctx.font = `${subtitle.sizePx || 48}px ${subtitle.font || 'Noto Sans KR'}`;
+
+  lines.forEach((line, idx) => {
+    const y = yBase + idx * ((subtitle.sizePx || 48) + 10);
+    const metrics = ctx.measureText(line);
+    const pad = 16;
+    ctx.fillStyle = subtitle.bgColor || '#000000';
+    ctx.globalAlpha = 0.65;
+    ctx.fillRect(width / 2 - metrics.width / 2 - pad, y - (subtitle.sizePx || 48), metrics.width + pad * 2, (subtitle.sizePx || 48) + 16);
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = subtitle.color || '#ffffff';
+    ctx.fillText(line, width / 2, y);
+  });
+}
+
+function breakLines(text, maxChars, maxLines) {
+  const words = text.split(' ');
+  const lines = [];
+  let line = '';
+  for (const w of words) {
+    if ((line + w).length > maxChars) {
+      lines.push(line.trim());
+      line = `${w} `;
+      if (lines.length >= maxLines) break;
+    } else {
+      line += `${w} `;
+    }
+  }
+  if (lines.length < maxLines && line.trim()) lines.push(line.trim());
+  return lines.slice(0, maxLines);
+}


### PR DESCRIPTION
### Motivation
- Provide a single-page web app to turn a script into a short YouTube-ready video with scene splitting, image prompts, thumbnails, TTS, subtitle styling and local video rendering.
- Enable using Gemini for scene analysis and Pollinations for free image generation while handling Google Cloud TTS integration and simple account switching UX.
- Support local rendering via a Web Worker and `OffscreenCanvas` to avoid blocking the UI and produce a downloadable video and ZIP export.

### Description
- Added a new web UI in `index.html` and styles in `styles.css` implementing inputs for Gemini API key/model, genre, script, subtitle styling, Google Cloud TTS key, voice selection, and controls for analyze/generate/render/download.
- Implemented main application logic in `app.js` including `geminiRequest` (LLM call), `generateImage` (Pollinations), TTS integration with Google Cloud (`checkTtsApiConnection`, `loadVoices`, `generateTtsForScenes`), localStorage management for keys/emails, scene UI rendering, and ZIP export via `JSZip` and `downloadBlob` utilities.
- Added background rendering worker `worker.js` that uses `OffscreenCanvas`, `MediaRecorder` and frame loop to draw scene images and subtitles, post progress events, and return a final `webm` blob to the main thread.
- Added project/agent documentation `docs/genspark-agent-instructions.md` and a Korean README `README.md` describing features, run instructions, and security/operational recommendations.
- Export/packaging support: `downloadAll` creates a ZIP containing scene texts, prompts, images, TTS audio, thumbnails, and `export/antigravity-project.json` from `buildProjectExport()`.

### Testing
- No automated tests were added or executed as part of this change (no CI test suite included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e58f91d88832a8f26eb96d04f9d4d)